### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,27 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2](https://github.com/felixpackard/cargo-test-changed/compare/v0.1.1...v0.1.2) - 2025-08-18
+
+### Fixed
+
+- *(deps)* update rust crate thiserror to v2.0.15
+- *(deps)* update rust crate clap to v4.5.45
+- *(deps)* update rust crate thiserror to v2.0.14
+- *(deps)* update rust crate anyhow to v1.0.99
+
+### Other
+
+- *(deps)* update actions/checkout action to v5
+- revert back clap-cargo update to save minimal supported rustc version
+- update dependicies
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-test-changed"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "A Cargo subcommand to run tests for changed crates and their dependents. "
 name = "cargo-test-changed"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION



## 🤖 New release

* `cargo-test-changed`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/felixpackard/cargo-test-changed/compare/v0.1.1...v0.1.2) - 2025-08-18

### Fixed

- *(deps)* update rust crate thiserror to v2.0.15
- *(deps)* update rust crate clap to v4.5.45
- *(deps)* update rust crate thiserror to v2.0.14
- *(deps)* update rust crate anyhow to v1.0.99

### Other

- *(deps)* update actions/checkout action to v5
- revert back clap-cargo update to save minimal supported rustc version
- update dependicies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).